### PR TITLE
MarkdownのタグにNDCの文字列を付与するscriptを作成

### DIFF
--- a/scripts/add_ndc_tag.py
+++ b/scripts/add_ndc_tag.py
@@ -51,6 +51,8 @@ def process_frontmatter(content):
         # 元のコンテンツを更新
         return f"---\n{new_frontmatter}\n---{content[match.end():]}"
     return content
+
+
 def process_markdown_files(directory):
     """指定ディレクトリ以下のMarkdownファイルを処理"""
     for root, _, files in os.walk(directory):

--- a/scripts/add_ndc_tag.py
+++ b/scripts/add_ndc_tag.py
@@ -1,8 +1,17 @@
 import os
 import re
+
+
 def is_number(s):
-    """文字列が数字かどうかをチェック"""
-    return s.isdigit()
+    """文字列が数字かK+数字かどうかをチェック"""
+    if s.isdigit():
+        return True
+    # Kで始まり、残りが数字の場合もTrue
+    if s.startswith('K') and s[1:].isdigit():
+        return True
+    return False
+
+
 def process_frontmatter(content):
     """Frontmatterを処理してタグを更新"""
     # YAMLフロントマターを探す
@@ -58,6 +67,8 @@ def process_markdown_files(directory):
                     with open(file_path, 'w', encoding='utf-8') as f:
                         f.write(new_content)
                     print(f"更新しました: {file_path}")
+
+
 if __name__ == "__main__":
     directory = "./aozorabunko"
     process_markdown_files(directory)

--- a/scripts/add_ndc_tag.py
+++ b/scripts/add_ndc_tag.py
@@ -1,0 +1,63 @@
+import os
+import re
+def is_number(s):
+    """文字列が数字かどうかをチェック"""
+    return s.isdigit()
+def process_frontmatter(content):
+    """Frontmatterを処理してタグを更新"""
+    # YAMLフロントマターを探す
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return content
+    frontmatter_text = match.group(1)
+    # タグ行を見つける
+    tag_match = re.search(r'^tags:(.*)$', frontmatter_text, re.MULTILINE)
+    if tag_match:
+        tags_text = tag_match.group(1).strip()
+        # 既存のタグをパース
+        if tags_text.startswith('[') and tags_text.endswith(']'):
+            # ["tag1", "tag2"] 形式の場合
+            tags = [tag.strip().strip('"\'') for tag in tags_text[1:-1].split(',') if tag.strip()]
+        elif tags_text:
+            # - tag1\n- tag2 形式の場合
+            tags = [tag.strip().strip('- ') for tag in tags_text.split('\n') if tag.strip()]
+        else:
+            tags = []
+        # タグを処理
+        new_tags = []
+        for tag in tags:
+            if tag and is_number(tag):
+                new_tags.append(f'NDC{tag}')
+            else:
+                new_tags.append(tag)
+        # 新しいタグ行を作成（["tag1", "tag2"]形式）
+        new_tags_text = f'tags: ["{"\", \"".join(new_tags)}"]'
+        # フロントマターを更新
+        new_frontmatter = re.sub(
+            r'^tags:.*?$',
+            new_tags_text,
+            frontmatter_text,
+            flags=re.MULTILINE
+        )
+        # 元のコンテンツを更新
+        return f"---\n{new_frontmatter}\n---{content[match.end():]}"
+    return content
+def process_markdown_files(directory):
+    """指定ディレクトリ以下のMarkdownファイルを処理"""
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith('.md'):
+                file_path = os.path.join(root, file)
+                # ファイルを読み込み
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                # フロントマターを処理
+                new_content = process_frontmatter(content)
+                # 変更があれば保存
+                if new_content != content:
+                    with open(file_path, 'w', encoding='utf-8') as f:
+                        f.write(new_content)
+                    print(f"更新しました: {file_path}")
+if __name__ == "__main__":
+    directory = "./aozorabunko"
+    process_markdown_files(directory)


### PR DESCRIPTION
`NDC`タグをMarkdownに付与するためのscriptを作成しました。

前回( #4 )はMarkdownのみをcommitしていたため、本PRではscriptが新規作成として反映されています。
※`K`から始まる数字にもタグを付与するcommitはこちら（ [fix: enable K-prefixed tag numbers for NDC format](https://github.com/ttizze/evame-data/pull/5/commits/22f046f3e25108b202841ae156b1288837cff385) ）

変更ファイル数が膨大になるため、今回はscriptのみの修正でPRを出します。